### PR TITLE
Adds ARM32/64 ELF Mapping Symbol Support

### DIFF
--- a/src/disasm/disassemble.cpp
+++ b/src/disasm/disassemble.cpp
@@ -91,7 +91,7 @@ void Disassemble::debug(const uint8_t *code, size_t length,
     cs_free(insn, count);
 }
 
-Module *Disassemble::module(ElfMap *elfMap, SymbolList *symbolList) {
+Module *Disassemble::module(ElfMap *elfMap, SymbolList *symbolList, MappingSymbolList *mappingSymbolList=nullptr) {
     Module *module = new Module();
     FunctionList *functionList = new FunctionList();
     module->getChildren()->add(functionList);

--- a/src/disasm/disassemble.h
+++ b/src/disasm/disassemble.h
@@ -28,7 +28,7 @@ public:
         address_t realAddress = 0, SymbolList *symbolList = 0);
 
     static void init();
-    static Module *module(ElfMap *elfMap, SymbolList *symbolList);
+    static Module *module(ElfMap *elfMap, SymbolList *symbolList, MappingSymbolList *mappingSymbolList);
     static Function *function(ElfMap *elfMap, Symbol *symbol);
     static Assembly makeAssembly(const std::vector<unsigned char> &str,
         address_t address = 0);

--- a/src/elf/elfspace.cpp
+++ b/src/elf/elfspace.cpp
@@ -19,7 +19,9 @@
 
 ElfSpace::ElfSpace(ElfMap *elf, SharedLib *library)
     : elf(elf), library(library), module(nullptr),
-    symbolList(nullptr), dynamicSymbolList(nullptr), relocList(nullptr),
+    symbolList(nullptr), dynamicSymbolList(nullptr),
+    mappingSymbolList(nullptr),
+    relocList(nullptr),
     aliasMap(nullptr) {
 
 }
@@ -30,6 +32,7 @@ ElfSpace::~ElfSpace() {
     delete module;
     delete symbolList;
     delete dynamicSymbolList;
+    delete mappingSymbolList;
     delete relocList;
     delete aliasMap;
 }
@@ -54,8 +57,12 @@ void ElfSpace::buildDataStructures(bool hasRelocs) {
         this->dynamicSymbolList = SymbolList::buildDynamicSymbolList(elf);
     }
 
+#if defined(ARCH_ARM) || defined(ARCH_AARCH64)
+    this->mappingSymbolList = MappingSymbolList::buildMappingSymbolList(this->symbolList);
+#endif
+
     Disassemble::init();
-    this->module = Disassemble::module(elf, symbolList);
+    this->module = Disassemble::module(elf, symbolList, mappingSymbolList);
     this->module->setElfSpace(this);
 
     InternalCalls internalCalls;

--- a/src/elf/elfspace.h
+++ b/src/elf/elfspace.h
@@ -20,6 +20,7 @@ private:
 private:
     SymbolList *symbolList;
     SymbolList *dynamicSymbolList;
+    MappingSymbolList *mappingSymbolList;
     RelocList *relocList;
     FunctionAliasMap *aliasMap;
 public:
@@ -38,6 +39,7 @@ public:
 
     SymbolList *getSymbolList() const { return symbolList; }
     SymbolList *getDynamicSymbolList() const { return dynamicSymbolList; }
+    MappingSymbolList *getMappingSymbolList() const { return mappingSymbolList; }
     RelocList *getRelocList() const { return relocList; }
 
     FunctionAliasMap *getAliasMap() const { return aliasMap; }

--- a/src/elf/symbol.cpp
+++ b/src/elf/symbol.cpp
@@ -140,8 +140,8 @@ SymbolList *SymbolList::buildSymbolList(ElfMap *elfmap) {
 
         // don't alias SECTIONs with other types (e.g. first FUNC in .text) or FILEs with other types
         if(sym->getType() == Symbol::TYPE_SECTION || sym->getType() == Symbol::TYPE_FILE) continue;
-#ifdef ARCH_AARCH64
-        // skip mapping symbols in AARCH64 ELF
+#if defined(ARCH_AARCH64) || defined(ARCH_ARM)
+        // skip mapping symbols
         if(sym->getName()[0] == '$') continue;
 #endif
 
@@ -289,4 +289,59 @@ Symbol::BindingType Symbol::bindFromElfToInternal(unsigned char type) {
     case STB_GLOBAL:    return Symbol::BIND_GLOBAL;
     default:            return Symbol::BIND_WEAK;
     }
+}
+
+bool Symbol::isMappingSymbol() const {
+    return this->bindingType == Symbol::BIND_LOCAL
+        && this->symbolType == Symbol::TYPE_UNKNOWN
+        && this->shndx != 0
+        && this->name[0] == '$';
+}
+
+Symbol::MappingType Symbol::mappingFromElfToInternal(unsigned char type) {
+  switch(type) {
+  case 'a': return Symbol::MAPPING_ARM;
+  case 't': return Symbol::MAPPING_THUMB;
+  case 'x': return Symbol::MAPPING_AARCH64;
+  default:  return Symbol::MAPPING_DATA;
+  }
+}
+
+bool MappingSymbolList::add(Symbol *symbol) {
+  symbolList.push_back(symbol);
+  symbolMap[symbol->getAddress()] = symbol;
+  return true;
+}
+
+Symbol *MappingSymbolList::find(address_t address) {
+  MapType::iterator exact, range;
+
+  exact = symbolMap.find(address);
+  if (exact != symbolMap.end()) {
+    return exact->second;
+  }
+
+  range=symbolMap.lower_bound(address);
+
+  if (range != symbolMap.begin()) {
+    return std::prev(range)->second;
+  }
+
+  return nullptr;
+}
+
+MappingSymbolList *MappingSymbolList::buildMappingSymbolList(SymbolList *symbolList) {
+
+    MappingSymbolList *list = new MappingSymbolList();
+
+    for (auto sym : *symbolList) {
+      if( sym->isMappingSymbol() ) {
+        Symbol::MappingType type = Symbol::mappingFromElfToInternal(sym->getName()[1]);
+        sym->setMappingType(type);
+        list->add(sym);
+      }
+    }
+
+    return list;
+
 }

--- a/src/elf/symbol.h
+++ b/src/elf/symbol.h
@@ -25,6 +25,14 @@ public:
         BIND_GLOBAL,
         BIND_WEAK
     };
+    // Only applicable for ARM architectures
+    enum MappingType {
+        MAPPING_ARM,
+        MAPPING_THUMB,
+        MAPPING_AARCH64,
+        MAPPING_DATA
+    };
+
 private:
     address_t address;
     size_t size;
@@ -33,6 +41,7 @@ private:
     std::vector<Symbol *> aliasList;
     SymbolType symbolType;
     BindingType bindingType;
+    MappingType mappingType;
     size_t index;
     size_t shndx;
 public:
@@ -59,11 +68,17 @@ public:
     const std::vector<Symbol *> &getAliases() const { return aliasList; }
 
     bool isFunction() const;
-public:
+
+    MappingType getMappingType() const { return mappingType; }
+    void setMappingType(MappingType type) { this->mappingType = type; }
+    bool isMappingSymbol() const;
+
+ public:
     static unsigned char typeFromInternalToElf(SymbolType type);
     static SymbolType typeFromElfToInternal(unsigned char type);
     static unsigned char bindFromInternalToElf(BindingType bind);
     static BindingType bindFromElfToInternal(unsigned char bind);
+    static MappingType mappingFromElfToInternal(unsigned char type);
 };
 
 class SymbolList {
@@ -97,6 +112,22 @@ private:
         const char *sectionName, unsigned sectionType);
     static Symbol *findSizeZero(SymbolList *list, const char *sym);
     void sortSymbols();
+};
+
+// Only applicable for ARM architectures
+class MappingSymbolList {
+private:
+    typedef std::vector<Symbol *> ListType;
+    ListType symbolList;
+    typedef std::map<address_t, Symbol *> MapType;
+    MapType symbolMap;
+public:
+    ListType::iterator begin() { return symbolList.begin(); }
+    ListType::iterator end() { return symbolList.end(); }
+    size_t getCount() const { return symbolList.size(); }
+    bool add(Symbol *symbol);
+    Symbol *find(address_t address);
+    static MappingSymbolList *buildMappingSymbolList(SymbolList *symbolList);
 };
 
 #endif


### PR DESCRIPTION
I didn't want to put all the MappingSymbol related classes in #ifdefs as I felt it made the code too difficult to read. Instead I opted out for leaving it null on x86 and not generating them.

This is needed to disassemble mixed arm/thumb code. 