### PR TITLE
Try both by name/hash for locating debug info file.

### DIFF
--- a/config/aarch64-Ubuntu.h
+++ b/config/aarch64-Ubuntu.h
@@ -7,7 +7,6 @@
 
 /* src */
 
-#define USR_LIB_DEBUG_BY_NAME
 #define CACHE_DIR "_cache"
 #define SANDBOX_BASE_ADDRESS    0x40000000
 #define JIT_TABLE_SIZE          64 * 0x1000 // must fit in 32-bit

--- a/config/aarch64-openSUSE.h
+++ b/config/aarch64-openSUSE.h
@@ -7,7 +7,6 @@
 
 /* src */
 
-#define USR_LIB_DEBUG_BY_NAME
 #define CACHE_DIR "_cache"
 #define SANDBOX_BASE_ADDRESS    0x40000000
 #define JIT_TABLE_SIZE          64 * 0x1000 // must fit in 32-bit

--- a/config/x86_64-Debian.h
+++ b/config/x86_64-Debian.h
@@ -7,7 +7,6 @@
 
 /* src */
 
-#define USR_LIB_DEBUG_BY_HASH
 #define SANDBOX_BASE_ADDRESS    0x40000000
 #define JIT_TABLE_SIZE          64 * 0x1000 // must fit in 32-bit
 

--- a/config/x86_64-Devuan.h
+++ b/config/x86_64-Devuan.h
@@ -7,7 +7,6 @@
 
 /* src */
 
-#define USR_LIB_DEBUG_BY_HASH
 #define SANDBOX_BASE_ADDRESS    0x40000000
 #define JIT_TABLE_SIZE          64 * 0x1000 // must fit in 32-bit
 

--- a/config/x86_64-Gentoo.h
+++ b/config/x86_64-Gentoo.h
@@ -7,7 +7,6 @@
 
 /* src */
 
-#define USR_LIB_DEBUG_BY_NAME
 #define SANDBOX_BASE_ADDRESS    0x40000000
 #define JIT_TABLE_SIZE          64 * 0x1000 // must fit in 32-bit
 

--- a/config/x86_64-Ubuntu.h
+++ b/config/x86_64-Ubuntu.h
@@ -7,7 +7,6 @@
 
 /* src */
 
-#define USR_LIB_DEBUG_BY_NAME
 #define SANDBOX_BASE_ADDRESS    0x40000000
 #define JIT_TABLE_SIZE          64 * 0x1000 // must fit in 32-bit
 

--- a/config/x86_64-openSUSE.h
+++ b/config/x86_64-openSUSE.h
@@ -7,7 +7,6 @@
 
 /* src */
 
-#define USR_LIB_DEBUG_BY_HASH
 #define HAVE_EXPLICIT_BZERO
 #define SANDBOX_BASE_ADDRESS    0x40000000
 #define JIT_TABLE_SIZE          64 * 0x1000 // must fit in 32-bit


### PR DESCRIPTION
This removes the config options `USR_LIB_DEBUG_BY_NAME` and `USR_LIB_DEBUG_BY_HASH`, in favour of simply trying both options to see if the file exists. This fixes a bug or two that @SleepyMug has run into with e.g. libselinux on Ubuntu 16.04 LTS, which has its debug info stored by hash, but libc's is stored by name.

There's likely other ways to accomplish this, so I'm open to suggestions.