### PR TITLE
Usedef updates

### DIFF
--- a/src/analysis/usedef.h
+++ b/src/analysis/usedef.h
@@ -394,6 +394,7 @@ private:
     void fillMovabs(UDState *state, AssemblyPtr assembly);
     void fillMovsxd(UDState *state, AssemblyPtr assembly);
     void fillMovzx(UDState *state, AssemblyPtr assembly);
+    void fillSyscall(UDState *state, AssemblyPtr assembly);
     void fillTest(UDState *state, AssemblyPtr assembly);
     void fillPush(UDState *state, AssemblyPtr assembly);
     void fillXor(UDState *state, AssemblyPtr assembly);


### PR DESCRIPTION
This adds support for noticing xors of a register against itself being a clear, and also allows for proper register value tracking across `syscall` instructions on Linux.