### PR TITLE
explicit FPIC flag for old compilers

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -121,6 +121,8 @@ $(PYSHELL): $(PYTHON_BINDING) python/shell.py
 	cp python/shell.py $(BUILDDIR)pyshell
 	chmod +x $(BUILDDIR)pyshell
 
+$(BUILDDIR)sandbox/inject/%.o: sandbox/inject/%.c
+	$(CC) $(CCFLAGS) -fPIC $(DEPFLAGS) -c -o $@ $<
 $(SANDBOX_LIBRARY): $(LIBSANDBOX_OBJECTS)
 	$(SHORT_LINK) -shared -fPIC -Wl,-soname,libsandbox.so $^ -o $@
 


### PR DESCRIPTION
Hey compilation didn't work on my machine with GCC 5. Needed to add this flag.