### PR TITLE
Handling CMOV in usedef analysis

### DIFF
--- a/src/analysis/slicingtree.h
+++ b/src/analysis/slicingtree.h
@@ -217,6 +217,11 @@ public:
     TreeNodeXor(TreeNode *left, TreeNode *right)
         : TreeNodeBinary(left, right, "^") {}
 };
+class TreeNodeCmov : public TreeNodeBinary {
+public:
+    TreeNodeCmov(TreeNode *src, TreeNode *dst)
+        : TreeNodeBinary(src, dst, "?->") {}
+};
 class TreeNodeDereferenceWithValue : public TreeNodeBinary {
 private:
     size_t width;

--- a/src/analysis/usedef.h
+++ b/src/analysis/usedef.h
@@ -394,6 +394,7 @@ private:
     void fillMovabs(UDState *state, AssemblyPtr assembly);
     void fillMovsxd(UDState *state, AssemblyPtr assembly);
     void fillMovzx(UDState *state, AssemblyPtr assembly);
+    void fillCmov(UDState *state, AssemblyPtr assembly);
     void fillSyscall(UDState *state, AssemblyPtr assembly);
     void fillTest(UDState *state, AssemblyPtr assembly);
     void fillPush(UDState *state, AssemblyPtr assembly);


### PR DESCRIPTION
Handle `cmov src, dst` as use `src` and `dst`, and def `dst`