### PR TITLE
Resolve calloc for latest libraries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "test/binary"]
 	path = test/binary
-	url = git@github.com:columbia/egalito-tests
+	url = https://github.com:columbia/egalito-tests
 [submodule "dep/capstone"]
 	path = dep/capstone
-	url = git@github.com:columbia/egalito-capstone
+	url = https://github.com:columbia/egalito-capstone
 [submodule "dep/distorm3"]
 	path = dep/distorm3
 	url = https://github.com/gdabah/distorm
 [submodule "docs"]
 	path = docs
-	url = git@github.com:columbia/egalito-docs.git
+	url = https://github.com:columbia/egalito-docs.git
 [submodule "dep/keystone"]
 	path = dep/keystone
-	url = git@github.com:keystone-engine/keystone.git
+	url = https://github.com:keystone-engine/keystone.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "test/binary"]
 	path = test/binary
-	url = git@github.com:columbia/egalito-tests
+	url = https://github.com/columbia/egalito-tests.git
 [submodule "dep/capstone"]
 	path = dep/capstone
-	url = git@github.com:columbia/egalito-capstone
+	url = https://github.com/columbia/egalito-capstone.git
 [submodule "dep/distorm3"]
 	path = dep/distorm3
 	url = https://github.com/gdabah/distorm
 [submodule "docs"]
 	path = docs
-	url = git@github.com:columbia/egalito-docs.git
+	url = https://github.com/columbia/egalito-docs.git
 [submodule "dep/keystone"]
 	path = dep/keystone
-	url = git@github.com:keystone-engine/keystone.git
+	url = https://github.com/keystone-engine/keystone.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "test/binary"]
 	path = test/binary
-	url = https://github.com:columbia/egalito-tests
+	url = git@github.com:columbia/egalito-tests
 [submodule "dep/capstone"]
 	path = dep/capstone
-	url = https://github.com:columbia/egalito-capstone
+	url = git@github.com:columbia/egalito-capstone
 [submodule "dep/distorm3"]
 	path = dep/distorm3
 	url = https://github.com/gdabah/distorm
 [submodule "docs"]
 	path = docs
-	url = https://github.com:columbia/egalito-docs.git
+	url = git@github.com:columbia/egalito-docs.git
 [submodule "dep/keystone"]
 	path = dep/keystone
-	url = https://github.com:keystone-engine/keystone.git
+	url = git@github.com:keystone-engine/keystone.git

--- a/dep/rtld/Makefile
+++ b/dep/rtld/Makefile
@@ -5,6 +5,8 @@ include ../../env.mk
 READELF = $(CROSS)readelf
 GDB = $(CROSS)gdb
 
+READELF_FLAGS = -W
+
 CFLAGS = -std=c99 -Wall -Wextra -Wno-format -Wno-int-conversion -Wno-unused-parameter -g
 CFLAGS_D =	-DRTLD_GLOBAL_SIZE=$(shell cat $(BUILDDIR)rtld_global_size) \
 		-DRTLD_GLOBAL_RO_SIZE=$(shell cat $(BUILDDIR)rtld_global_ro_size)
@@ -39,12 +41,12 @@ $(BUILDDIR):
 depends: $(BUILDDIR)interpreter $(BUILDDIR)rtld_global_size $(BUILDDIR)rtld_global_ro_size | $(BUILDDIR)
 
 $(BUILDDIR)interpreter: $(BUILDDIR)load_test
-	$(eval INTERPRETER_NAME = $(shell $(READELF) -l $(BUILDDIR)load_test | perl -ne '/\[Requesting program interpreter: (.*)\/(.*)\]/ && print "$$2\n"'))
+	$(eval INTERPRETER_NAME = $(shell $(READELF) $(READELF_FLAGS) -l $(BUILDDIR)load_test | perl -ne '/\[Requesting program interpreter: (.*)\/(.*)\]/ && print "$$2\n"'))
 	readlink -f $(shell $(CC) --print-file-name=$(INTERPRETER_NAME)) > $@
 $(BUILDDIR)rtld_global_size: $(BUILDDIR)interpreter
-	$(READELF) --dyn-syms $(shell cat $(BUILDDIR)interpreter) | grep rtld_global@ | awk '{ print $$3 }' > $@
+	$(READELF) $(READELF_FLAGS) --dyn-syms $(shell cat $(BUILDDIR)interpreter) | grep rtld_global@ | awk '{ print $$3 }' > $@
 $(BUILDDIR)rtld_global_ro_size: $(BUILDDIR)interpreter
-	$(READELF) --dyn-syms $(shell cat $(BUILDDIR)interpreter) | grep rtld_global_ro@ | awk '{ print $$3 }' > $@
+	$(READELF) $(READELF_FLAGS) --dyn-syms $(shell cat $(BUILDDIR)interpreter) | grep rtld_global_ro@ | awk '{ print $$3 }' > $@
 
 $(BUILDDIR)rtld.h: | depends
 	$(RUN_GDB) -x rtld.gdb $(shell cat $(BUILDDIR)interpreter) | grep -v 'done\.' | grep -v 'Reading symbols' \

--- a/src/analysis/controlflow.cpp
+++ b/src/analysis/controlflow.cpp
@@ -45,6 +45,11 @@ ControlFlowGraph::~ControlFlowGraph() {
     }
 }
 
+std::vector<ControlFlowNode> ControlFlowGraph::getGraph()
+{
+    return graph;
+}
+
 void ControlFlowGraph::construct(Function *function) {
     ControlFlowNode::id_t count = 0;
     for(auto b : function->getChildren()->getIterable()->iterable()) {

--- a/src/analysis/controlflow.h
+++ b/src/analysis/controlflow.h
@@ -75,7 +75,7 @@ public:
     virtual size_t getCount() const { return graph.size(); }
 
     id_t getIDFor(Block *block) { return blockMapping[block]; }
-
+    std::vector<ControlFlowNode> getGraph();
     void dump();
     void dumpDot();
 private:

--- a/src/analysis/controlflow.h
+++ b/src/analysis/controlflow.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <map>
-#include <string.h>
+#include <string>
 #include "analysis/graph.h"
 #include "util/iter.h"
 

--- a/src/analysis/controlflow.h
+++ b/src/analysis/controlflow.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <map>
+#include <string.h>
 #include "analysis/graph.h"
 #include "util/iter.h"
 

--- a/src/analysis/jumptable.h
+++ b/src/analysis/jumptable.h
@@ -26,12 +26,13 @@ private:
     Register indexRegister;
     int scale;
     long bound;
+    int signedOrZero;
 public:
     JumpTableDescriptor(Function *function, Instruction *instruction)
         : function(function), instruction(instruction),
         address(0), contentSection(nullptr), targetBaseLink(nullptr),
         indexExpr(nullptr), indexRegister(INVALID_REGISTER), scale(1),
-        bound(LONG_MAX) {}
+        bound(LONG_MAX), signedOrZero(1) {}
 
     Function *getFunction() const { return function; }
     Instruction *getInstruction() const { return instruction; }
@@ -41,6 +42,7 @@ public:
     TreeNode *getIndexExpr() const { return indexExpr; }
     Register getIndexRegister() const { return indexRegister; }
     int getScale() const { return scale; }
+    int getSignedOrZero() const { return signedOrZero; }
     long getBound() const { return bound; }
     bool isBoundKnown() const { return bound != LONG_MAX; }
     long getEntries() const;
@@ -53,6 +55,7 @@ public:
     void setScale(int scale) { this->scale = scale; }
     void setBound(long bound) { this->bound = bound; }
     void setEntries(long entries) { this->bound = entries - 1; }
+    void setSignedOrZero(int signedOrZero) { this->signedOrZero = signedOrZero; }
 };
 
 #if 0

--- a/src/analysis/jumptabledetection.cpp
+++ b/src/analysis/jumptabledetection.cpp
@@ -364,6 +364,11 @@ bool JumptableDetection::parseJumptableWithIndexTable(UDState *state,
             LOG(10, "JUMP TABLE ACCESS FOUND!");
             info->tableBase = address;
             info->scale = scaleTree->getValue();
+            auto jsAssembly = js->getInstruction()->getSemantic()->getAssembly();
+            if(jsAssembly->getId() == X86_INS_MOVZX)
+                info->signedOrZero=0;
+            else if ((jsAssembly->getId() == X86_INS_MOVSB) || (jsAssembly->getId() == X86_INS_MOVSD) || (jsAssembly->getId() == X86_INS_MOVSHDUP) || (jsAssembly->getId() == X86_INS_MOVSLDUP) || (jsAssembly->getId() == X86_INS_MOVSQ) || (jsAssembly->getId() == X86_INS_MOVSS) || (jsAssembly->getId() == X86_INS_MOVSW) || (jsAssembly->getId() == X86_INS_MOVSX) || (jsAssembly->getId() == X86_INS_MOVSXD)) 
+                info->signedOrZero=1;
 
             auto reg = regTree2->getRegister();
             LOG(10, "trying to find index table from "
@@ -437,6 +442,7 @@ void JumptableDetection::makeDescriptor(Instruction *instruction,
     assert(link);
     jtd->setTargetBaseLink(link);
     jtd->setScale(info->scale);
+    jtd->setSignedOrZero(info->signedOrZero);
     jtd->setEntries(info->entries);
 
     auto contentSection =
@@ -510,6 +516,11 @@ bool JumptableDetection::parseTableAccess(UDState *state, int reg,
             LOG(10, "TABLE ACCESS FOUND! deref=" << deref);
             info->tableBase = address;
             info->scale = scaleTree->getValue();
+            auto jsAssembly = s->getInstruction()->getSemantic()->getAssembly();
+            if(jsAssembly->getId() == X86_INS_MOVZX)
+                info->signedOrZero=0;
+            else if ((jsAssembly->getId() == X86_INS_MOVSB) || (jsAssembly->getId() == X86_INS_MOVSD) || (jsAssembly->getId() == X86_INS_MOVSHDUP) || (jsAssembly->getId() == X86_INS_MOVSLDUP) || (jsAssembly->getId() == X86_INS_MOVSQ) || (jsAssembly->getId() == X86_INS_MOVSS) || (jsAssembly->getId() == X86_INS_MOVSW) || (jsAssembly->getId() == X86_INS_MOVSX) || (jsAssembly->getId() == X86_INS_MOVSXD)) 
+                info->signedOrZero=1;
             if(!deref) {
                 parseBound(s, regTree2->getRegister(), info);
             }
@@ -570,6 +581,11 @@ bool JumptableDetection::parseTableAccess(UDState *state, int reg,
 
             auto deref = dynamic_cast<TreeNodeDereference *>(cap.get(0));
             info->scale = deref->getWidth();
+            auto jsAssembly = s->getInstruction()->getSemantic()->getAssembly();
+            if(jsAssembly->getId() == X86_INS_MOVZX)
+                info->signedOrZero=0;
+            else if ((jsAssembly->getId() == X86_INS_MOVSB) || (jsAssembly->getId() == X86_INS_MOVSD) || (jsAssembly->getId() == X86_INS_MOVSHDUP) || (jsAssembly->getId() == X86_INS_MOVSLDUP) || (jsAssembly->getId() == X86_INS_MOVSQ) || (jsAssembly->getId() == X86_INS_MOVSS) || (jsAssembly->getId() == X86_INS_MOVSW) || (jsAssembly->getId() == X86_INS_MOVSX) || (jsAssembly->getId() == X86_INS_MOVSXD)) 
+                info->signedOrZero=1;
 
             parseBound(s, regTree2->getRegister(), info);
             return true;

--- a/src/analysis/jumptabledetection.h
+++ b/src/analysis/jumptabledetection.h
@@ -87,7 +87,7 @@ private:
     bool getBoundFromControlFlow(UDState *state, int reg, JumptableInfo *info);
 
     void collectJumpsTo(UDState *state, JumptableInfo *info,
-        std::vector<UDState *>& result);
+        std::set<UDState *>& visited, std::vector<UDState *>& result);
     bool valueReaches(UDState *state, int reg, UDState *state2, int reg2,
         long *boundValue);
 };

--- a/src/analysis/jumptabledetection.h
+++ b/src/analysis/jumptabledetection.h
@@ -24,12 +24,13 @@ private:
         address_t targetBase;
         address_t tableBase;
         size_t scale;
+        int signedOrZero;
         long entries;
 
         JumptableInfo(ControlFlowGraph *cfg, UDRegMemWorkingSet *working,
             UDState *state)
             : cfg(cfg), working(working), jumpState(state), valid(false),
-              targetBase(0), tableBase(0), scale(0), entries(0) {}
+              targetBase(0), tableBase(0), scale(0), entries(0), signedOrZero(1) {}
     };
 
     struct IndextableInfo {

--- a/src/analysis/usedef.cpp
+++ b/src/analysis/usedef.cpp
@@ -2034,11 +2034,11 @@ void UseDef::fillCMov(UDState *state, AssemblyPtr assembly) {
         size_t width = inferAccessWidth(
             &assembly->getAsmOperands()->getOperands()[1]);
         fillMemToReg(state, assembly, width);
-        LOG(1, "CMOV MEM TO REG");
+        //LOG(1, "CMOV MEM TO REG");
     }
     else if(mode == AssemblyOperands::MODE_REG_REG) {
         fillRegToReg(state, assembly);
-        LOG(1, "CMOV REG TO REG");
+        //LOG(1, "CMOV REG TO REG");
     }
     else {
         LOG(1, "CMOV skipping mode " << mode);

--- a/src/analysis/usedef.cpp
+++ b/src/analysis/usedef.cpp
@@ -14,10 +14,7 @@
 DefList::~DefList() {
     for(auto tn : list) 
     {
-        if(!tn.second)
-        {
-            delete tn.second;
-        }
+        delete tn.second;
     }
 }
 

--- a/src/analysis/usedef.cpp
+++ b/src/analysis/usedef.cpp
@@ -12,7 +12,13 @@
 #include "log/log.h"
 
 DefList::~DefList() {
-    for(auto tn : list) delete tn.second;
+    for(auto tn : list) 
+    {
+        if(!tn.second)
+        {
+            delete tn.second;
+        }
+    }
 }
 
 void DefList::set(int reg, TreeNode *tree) {

--- a/src/analysis/usedef.h
+++ b/src/analysis/usedef.h
@@ -391,6 +391,8 @@ private:
     void fillJmp(UDState *state, AssemblyPtr assembly);
     void fillLea(UDState *state, AssemblyPtr assembly);
     void fillMov(UDState *state, AssemblyPtr assembly);
+    void fillCMov(UDState *state, AssemblyPtr assembly);
+    void fillX86Ret(UDState *state, AssemblyPtr assembly);   
     void fillMovabs(UDState *state, AssemblyPtr assembly);
     void fillMovsxd(UDState *state, AssemblyPtr assembly);
     void fillMovzx(UDState *state, AssemblyPtr assembly);
@@ -467,6 +469,7 @@ public:
     bool operator!=(const MemLocation& other) const
         { return !this->reg->equal(other.reg) || this->offset != other.offset; }
     TreeNode *getRegTree() const { return reg; }
+    long int getOffset() { return offset; }
 private:
     void extract(TreeNode *tree);
 };

--- a/src/chunk/dump.cpp
+++ b/src/chunk/dump.cpp
@@ -343,9 +343,27 @@ void InstrDumper::visit(IndirectCallInstruction *semantic) {
     std::string bytes = getBytes(semantic);
     std::string bytes2 = DisasmDump::formatBytes(bytes.c_str(), bytes.size());
 
+    std::string indirectcallTargets;
+    auto icTargets = semantic->getIndirectCallTargets();
+    std::ostringstream targetStream;
+    for(int i=0; i<icTargets.size(); i++) {
+            if(i>0)
+                targetStream << ", ";
+            if(icTargets[i].isUnknown())
+                targetStream << "?";
+            else if(icTargets[i].isGlobal()) {
+                 targetStream << "*(0x" << std::hex << icTargets[i].getAddress() <<") <?>";
+            }
+            else {
+                 targetStream << "0x"<<std::hex << icTargets[i].getAddress() << "<" << icTargets[i].getName() << ">";
+            }
+            indirectcallTargets = targetStream.str();
+    }
     DisasmDump::printInstructionRaw(address,
         pos, "(CALL*)",
-        semantic->getAssembly()->getOpStr().c_str(), nullptr, bytes2.c_str(),
+        semantic->getAssembly()->getOpStr().c_str(),
+        indirectcallTargets.c_str(),
+        bytes2.c_str(),
         false);
 }
 

--- a/src/chunk/ictarget.cpp
+++ b/src/chunk/ictarget.cpp
@@ -1,0 +1,37 @@
+#include "ictarget.h"
+
+
+
+IndirectCallTarget::IndirectCallTarget(address_t address) : address(address),global(false),unknown(false) { }
+
+address_t IndirectCallTarget::getAddress() {
+	return address;
+}
+
+void IndirectCallTarget::setAddress(address_t address) {
+	this->address = address;
+}
+
+void IndirectCallTarget::setName(string str) {
+	name = str;
+}
+
+string IndirectCallTarget::getName() {
+	return name;
+}
+
+void IndirectCallTarget::setGlobal() {
+	global = true;
+}
+
+void IndirectCallTarget::setUnknown() {
+	unknown = true;
+}
+
+bool IndirectCallTarget::isGlobal() {
+	return global;
+}
+
+bool IndirectCallTarget::isUnknown() {
+	return unknown;
+}

--- a/src/chunk/ictarget.h
+++ b/src/chunk/ictarget.h
@@ -1,0 +1,33 @@
+#ifndef EGALITO_CHUNK_ICTARGET_H
+#define EGALITO_CHUNK_ICTARGET_H
+
+#include<string>
+using namespace std;
+
+#include "chunk/chunk.h"
+
+
+class IndirectCallTarget : public ChunkImpl {
+
+	private :
+		address_t address;
+		string name;
+		bool global;
+		bool unknown;
+
+	public:
+		IndirectCallTarget() : address(0),global(false),unknown(false) {}
+		IndirectCallTarget(address_t address);
+		void setName(string str);
+		void setGlobal();
+		void setUnknown();
+		string getName();
+		bool isGlobal();
+		bool isUnknown();
+
+
+		virtual void accept(ChunkVisitor *visitor) {}
+		virtual address_t getAddress();
+		virtual void setAddress(address_t address);
+};
+#endif

--- a/src/chunk/marker.cpp
+++ b/src/chunk/marker.cpp
@@ -94,7 +94,7 @@ Link *MarkerList::createMarkerLink(Symbol *symbol, size_t addend,
 #ifndef LINUX_KERNEL_MODE
     // during Linux kernel boot, a pointer must point to a strage address
     // just leave the original
-    assert("couldn't find the base of marker..." && 0);
+    //assert("couldn't find the base of marker..." && 0);
 #endif
     return nullptr;
 }

--- a/src/chunk/resolver.cpp
+++ b/src/chunk/resolver.cpp
@@ -316,6 +316,12 @@ Link *PerfectLinkResolver::resolveInternally(Reloc *reloc, Module *module,
             // value should be S
             addr = symbol->getAddress();
         }
+        
+        else if(type >= R_X86_64_NUM) {
+           // some ELFs with debug symbols use relocations of type 82 etc
+            LOG(1, "Handing unrecognized relocations ");
+            addr = symbol->getAddress();
+        }
         else {
             // value should be S+A
             addr += symbol->getAddress();

--- a/src/chunk/resolver.cpp
+++ b/src/chunk/resolver.cpp
@@ -25,62 +25,67 @@ static void appendNop(Function *function, size_t size) {
 
     DisasmHandle handle(true);
     Instruction *i = nullptr;
-    switch(size) {
-    case 1:
-        i = DisassembleInstruction(handle).instruction(
-            std::vector<unsigned char>({0x90}));
-        break;
-    case 2:
-        i = DisassembleInstruction(handle).instruction(
-            std::vector<unsigned char>({0x66, 0x90}));
-        break;
-    case 3:
-        i = DisassembleInstruction(handle).instruction(
-            std::vector<unsigned char>({0x0f, 0x1f, 0x00}));
-        break;
-    case 4:
-        i = DisassembleInstruction(handle).instruction(
-            std::vector<unsigned char>({0x0f, 0x1f, 0x40, 0x00}));
-        break;
-    case 5:
-        i = DisassembleInstruction(handle).instruction(
-            std::vector<unsigned char>({0x0f, 0x1f, 0x44, 0x00, 0x00}));
-        break;
-    case 6:
-        i = DisassembleInstruction(handle).instruction(
-            std::vector<unsigned char>({0x66, 0x0f, 0x1f, 0x44, 0x00, 0x00}));
-        break;
-    case 7:
-        i = DisassembleInstruction(handle).instruction(
-            std::vector<unsigned char>(
-                {0x0f, 0x1f, 0x80, 0x00, 0x00, 0x00, 0x00}));
-        break;
-    case 8:
-        i = DisassembleInstruction(handle).instruction(
-            std::vector<unsigned char>(
-                {0x0f, 0x1f, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00}));
-        break;
-    case 9:
-        i = DisassembleInstruction(handle).instruction(
-            std::vector<unsigned char>(
-                {0x66, 0x0f, 0x1f, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00}));
-        break;
-    case 10:
-        i = DisassembleInstruction(handle).instruction(
-            std::vector<unsigned char>(
-                {0x66, 0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00}));
-        break;
-    case 11:
-        i = DisassembleInstruction(handle).instruction(
-            std::vector<unsigned char>(
-                {0x66, 0x66, 0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00}));
-        break;
-    default:
-        LOG(1, "NYI: appendNop for " << size);
-        break;
-    }
-    assert(i);
-    ChunkMutator(block).append(i);
+    do {
+        size_t nextSize = (size > 11 ? 11 : size);
+        size -= nextSize;
+        switch(nextSize) {
+        case 1:
+            i = DisassembleInstruction(handle).instruction(
+                std::vector<unsigned char>({0x90}));
+            break;
+        case 2:
+            i = DisassembleInstruction(handle).instruction(
+                std::vector<unsigned char>({0x66, 0x90}));
+            break;
+        case 3:
+            i = DisassembleInstruction(handle).instruction(
+                std::vector<unsigned char>({0x0f, 0x1f, 0x00}));
+            break;
+        case 4:
+            i = DisassembleInstruction(handle).instruction(
+                std::vector<unsigned char>({0x0f, 0x1f, 0x40, 0x00}));
+            break;
+        case 5:
+            i = DisassembleInstruction(handle).instruction(
+                std::vector<unsigned char>({0x0f, 0x1f, 0x44, 0x00, 0x00}));
+            break;
+        case 6:
+            i = DisassembleInstruction(handle).instruction(
+                std::vector<unsigned char>({0x66, 0x0f, 0x1f, 0x44, 0x00, 0x00}));
+            break;
+        case 7:
+            i = DisassembleInstruction(handle).instruction(
+                std::vector<unsigned char>(
+                    {0x0f, 0x1f, 0x80, 0x00, 0x00, 0x00, 0x00}));
+            break;
+        case 8:
+            i = DisassembleInstruction(handle).instruction(
+                std::vector<unsigned char>(
+                    {0x0f, 0x1f, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00}));
+            break;
+        case 9:
+            i = DisassembleInstruction(handle).instruction(
+                std::vector<unsigned char>(
+                    {0x66, 0x0f, 0x1f, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00}));
+            break;
+        case 10:
+            i = DisassembleInstruction(handle).instruction(
+                std::vector<unsigned char>(
+                    {0x66, 0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00}));
+            break;
+        case 11:
+            i = DisassembleInstruction(handle).instruction(
+                std::vector<unsigned char>(
+                    {0x66, 0x66, 0x66, 0x0F, 0x1F, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00}));
+            break;
+        default:
+            LOG(1, "NYI: appendNop for " << nextSize);
+            break;
+        }
+        assert(i);
+        ChunkMutator(block).append(i);
+    } while(size > 0);
+
     ChunkMutator(function).append(block);
 #endif
 }

--- a/src/elf/elfdynamic.cpp
+++ b/src/elf/elfdynamic.cpp
@@ -111,10 +111,10 @@ void ElfDynamic::setupSearchPath() {
         parentPath=currentPath.substr(0,index);
     }
 
-    std::string libPath = parentPath + "/binaries/final";
+    //std::string libPath = parentPath + "/binaries/final";
     std::string libcPath = parentPath + "/binaries/final/libc";
 
-    searchPath.push_back(cfs->transform(libPath));
+    //searchPath.push_back(cfs->transform(libPath));
     searchPath.push_back(cfs->transform(libcPath));
 
     if(musl) {

--- a/src/elf/elfdynamic.cpp
+++ b/src/elf/elfdynamic.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <elf.h>
 #include <glob.h>
+#include <unistd.h>
 
 #include "elfdynamic.h"
 #include "elfmap.h"
@@ -89,6 +90,33 @@ void ElfDynamic::setupSearchPath() {
     int musl = isFeatureEnabled("EGALITO_MUSL");
 
     auto cfs = ConductorFilesystem::getInstance();
+
+    char *cwd = get_current_dir_name();
+    std::string currentPath(cwd);
+    int count=0;
+    int index=-1;
+    std::string parentPath;
+    for(int i=currentPath.length()-1; i>=0; i--)
+    {
+        if(currentPath[i]=='/')
+            count++;
+        if(count==2)
+        {
+            index=i;
+            break;
+        }
+    }
+    if(index != -1)
+    {
+        parentPath=currentPath.substr(0,index);
+    }
+
+    std::string libPath = parentPath + "/binaries/final";
+    std::string libcPath = parentPath + "/binaries/final/libc";
+
+    searchPath.push_back(cfs->transform(libPath));
+    searchPath.push_back(cfs->transform(libcPath));
+
     if(musl) {
         parseMuslLdConfig(cfs->transform("/etc/ld-musl-x86_64.path"), searchPath);
     }

--- a/src/elf/elfdynamic.cpp
+++ b/src/elf/elfdynamic.cpp
@@ -227,7 +227,7 @@ void ElfDynamic::processLibrary(const std::string &fullPath,
         || filename == "ld-linux-riscv64-lp64d.so.1") {
 
         LOG(2, "    skipping processing of ld.so for now");
-        return;
+        //return;
     }
     if(!isFeatureEnabled("EGALITO_USE_DISASM")) {
         if(filename == "libcapstone.so.4" || filename == "libcapstone.so.3") {

--- a/src/elf/elfdynamic.cpp
+++ b/src/elf/elfdynamic.cpp
@@ -111,14 +111,12 @@ void ElfDynamic::setupSearchPath() {
         parentPath=currentPath.substr(0,index);
     }
 
-    std::string libPath = parentPath + "/binaries/final";
-    std::string otherlibPath = parentPath + "/binaries/final/others";
-    std::string libcPath = parentPath + "/binaries/final/libc";
+    const char *user_library_path = getenv("USER_LIBRARY_PATH");
+    if(user_library_path) {
+        split(user_library_path, ':', std::back_inserter(searchPath));
+    }
 
-    //searchPath.push_back(cfs->transform(libPath));
-    //searchPath.push_back(cfs->transform(otherlibPath));
 
-    //searchPath.push_back(cfs->transform(libcPath));
 
     if(musl) {
         parseMuslLdConfig(cfs->transform("/etc/ld-musl-x86_64.path"), searchPath);

--- a/src/elf/elfdynamic.cpp
+++ b/src/elf/elfdynamic.cpp
@@ -111,11 +111,14 @@ void ElfDynamic::setupSearchPath() {
         parentPath=currentPath.substr(0,index);
     }
 
-    //std::string libPath = parentPath + "/binaries/final";
+    std::string libPath = parentPath + "/binaries/final";
+    std::string otherlibPath = parentPath + "/binaries/final/others";
     std::string libcPath = parentPath + "/binaries/final/libc";
 
     //searchPath.push_back(cfs->transform(libPath));
-    searchPath.push_back(cfs->transform(libcPath));
+    //searchPath.push_back(cfs->transform(otherlibPath));
+
+    //searchPath.push_back(cfs->transform(libcPath));
 
     if(musl) {
         parseMuslLdConfig(cfs->transform("/etc/ld-musl-x86_64.path"), searchPath);

--- a/src/elf/elfdynamic.cpp
+++ b/src/elf/elfdynamic.cpp
@@ -223,12 +223,15 @@ void ElfDynamic::resolveLibraries() {
 void ElfDynamic::processLibrary(const std::string &fullPath,
     const std::string &filename, Library *depend) {
 
+   int isLdEnabled = isFeatureEnabled("ENABLE_LD");
+
     if(filename == "ld-linux-x86-64.so.2"
         || filename == "ld-linux-aarch64.so.1"
         || filename == "ld-linux-riscv64-lp64d.so.1") {
 
         LOG(2, "    skipping processing of ld.so for now");
-        //return;
+	if (!isLdEnabled)
+        	return;
     }
     if(!isFeatureEnabled("EGALITO_USE_DISASM")) {
         if(filename == "libcapstone.so.4" || filename == "libcapstone.so.3") {

--- a/src/instr/concrete.h
+++ b/src/instr/concrete.h
@@ -121,6 +121,8 @@ public:
 
         void addIndirectCallTarget(IndirectCallTarget icTarget) { targets.push_back(icTarget); }
 
+        void clearAllTargets() { targets.clear(); };
+
         virtual void accept(InstructionVisitor *visitor) { visitor->visit(this); }
 };
 

--- a/src/instr/concrete.h
+++ b/src/instr/concrete.h
@@ -3,6 +3,9 @@
 
 #include "semantic.h"
 #include "register.h"
+#include "chunk/ictarget.h"
+#include<vector>
+using namespace std;
 
 class IsolatedInstruction : public SemanticImpl {
 public:
@@ -109,7 +112,16 @@ class IndirectCallInstruction : public IndirectControlFlowInstructionBase {
 public:
     using IndirectControlFlowInstructionBase::IndirectControlFlowInstructionBase;
 
-    virtual void accept(InstructionVisitor *visitor) { visitor->visit(this); }
+private:
+    vector<IndirectCallTarget> targets;
+
+public:
+
+        const std::vector<IndirectCallTarget> getIndirectCallTargets() const { return targets; }
+
+        void addIndirectCallTarget(IndirectCallTarget icTarget) { targets.push_back(icTarget); }
+
+        virtual void accept(InstructionVisitor *visitor) { visitor->visit(this); }
 };
 
 // brk and hlt

--- a/src/pass/findsyscalls.cpp
+++ b/src/pass/findsyscalls.cpp
@@ -59,7 +59,7 @@ void FindSyscalls::visit(Function *function) {
                 else {
                     func_target = dynamic_cast<Function *>(target);
                 }
-                if (func_target && isSyscallFunction(function)) {
+                if (func_target && isSyscallFunction(func_target)) {
                     LOG(10, "found call to syscall() function");
                     std::set<unsigned long> values;
                     seen.clear();

--- a/src/pass/findsyscalls.cpp
+++ b/src/pass/findsyscalls.cpp
@@ -19,6 +19,12 @@ void FindSyscalls::visit(Function *function) {
     if (isSyscallFunction(function)) return;
 
     auto graph = new ControlFlowGraph(function);
+    if(graph->getCount() == 0) {
+        LOG(1, "Skipping function " << function->getName()
+            << " with empty CFG");
+        delete graph;
+        return;
+    }
     auto config = new UDConfiguration(graph);
     auto working = new UDRegMemWorkingSet(function, graph);
     auto usedef = new UseDef(config, working);

--- a/src/pass/handledatarelocs.cpp
+++ b/src/pass/handledatarelocs.cpp
@@ -169,6 +169,45 @@ Link *HandleDataRelocsPass::resolveVariableLink(Reloc *reloc, Module *module) {
             return nullptr;
         }
     }
+    else if(reloc->getType() == R_X86_64_JUMP_SLOT) {
+        if(reloc->getAddend() != 0) {
+            // Non-zero addend is a data reference (e.g. calloc + 28454),
+            // not a function call. Store as ExternalSymbolLink with offset.
+            LOG(0, "processing R_X86_64_JUMP_SLOT with addend ("
+                << std::hex << reloc->getAddress()
+                << ") in " << module->getName()
+                << ", symbol=" << reloc->getSymbol()->getName()
+                << ", addend=" << std::dec << reloc->getAddend());
+            auto externalSymbol = ExternalSymbolFactory(module)
+                .makeExternalSymbol(reloc->getSymbol());
+            return new ExternalSymbolLink(externalSymbol, reloc->getAddend());
+        }
+        if(!internal) {
+            LOG(0, "processing R_X86_64_JUMP_SLOT ("
+                << std::hex << reloc->getAddress()
+                << ") in " << module->getName());
+            auto l = PerfectLinkResolver().resolveExternally(
+                reloc->getSymbol(), conductor, module, weak, false, true);
+            if(!l) {
+                l = PerfectLinkResolver().resolveInternally(reloc, module, weak, false);
+            }
+            LOG(0, "link is " << l);
+            return l;
+        }
+        else {
+            LOG(0, "checking JUMP_SLOT relocation ["
+                << reloc->getSymbol()->getName() << "] for internal link");
+            auto l = PerfectLinkResolver().resolveInternally(reloc, module, weak, false);
+            if(auto v = dynamic_cast<AbsoluteDataLink *>(l)) {
+                auto externalSymbol = ExternalSymbolFactory(module)
+                    .makeExternalSymbol(reloc->getSymbol());
+                auto newLink = new InternalAndExternalDataLink(externalSymbol, v);
+                delete v;
+                return newLink;
+            }
+            return nullptr;
+        }
+    }
     else if(reloc->getType() == R_X86_64_64) {
         // want a non-relative lookup
         auto l =  PerfectLinkResolver().resolveInternally(reloc, module, weak, false);

--- a/src/pass/syspartpass.cpp
+++ b/src/pass/syspartpass.cpp
@@ -43,7 +43,7 @@ void SyspartPass::visit(Module *module) {
 void SyspartPass::visit(Function *func)
 {
 
-    LOG(1, "SID "<<func->getName());
+    
 	if((func->getName() == this->function->getName()) && (func->getAddress() == this->function->getAddress()))
 	{
 		for(auto bl : CIter::children(this->function))
@@ -112,9 +112,10 @@ void SyspartPass::visit(Function *func)
                 auto last =  (Instruction*)bl->getChildren()->genericGetLast();
                 if(auto cfi = dynamic_cast<ControlFlowInstruction *>(last->getSemantic())) 
                 {
-                    cout<<"CFI at "<< std::hex<<last->getAddress()<<endl;
+                    //cout<<"CFI at "<< std::hex<<last->getAddress()<<endl;
                     auto sem1 = last->getSemantic();
-                    if(auto linked = dynamic_cast<LinkedInstructionBase *>(sem1))
+                    /*
+		    if(auto linked = dynamic_cast<LinkedInstructionBase *>(sem1))
                     {
                         cout<<"LINKED INSTRUCTION BASE"<<endl;
                     }
@@ -126,6 +127,7 @@ void SyspartPass::visit(Function *func)
                     {
                        cout<<"JUMP HERE"<<endl;
                     }
+		    */
                 }
                 m1.insertBefore(last, call);
 

--- a/src/pass/syspartpass.cpp
+++ b/src/pass/syspartpass.cpp
@@ -39,61 +39,6 @@ void SyspartPass::visit(Module *module) {
 
 #endif
 }
-/*
-void SyspartPass::visit(Function *func)
-{
-
-    
-	if((func->getName() == this->function->getName()) && (func->getAddress() == this->function->getAddress()))
-	{
-		for(auto bl : CIter::children(this->function))
-		{
-			for(auto instr : CIter::children(bl))
-			{
-				if(instr->getAddress() == this->address)
-				{
-                    auto block2 = new Block();
-                    //PositionFactory *positionFactory = PositionFactory::getInstance();
-                    //block2->setPosition(positionFactory->makePosition(bl, block2, bl->getSize()));
-                    ChunkMutator m1(block2);
-
-					auto call = new Instruction();
-					auto callSem = new ControlFlowInstruction(
-            X86_INS_CALL, call, "\xe8", "call", 4);
-                    auto module = (Module*)func->getParent()->getParent();
-                    auto newRef = CIter::named(module->getPLTList())->find(enforcement_func->getName());
-                    if(newRef)
-                    {
-                        LOG(1, "YEAH PLT ENTRY FOUND");
-                        callSem->setLink(new PLTLink(newRef->getAddress(), newRef));
-                    }
-                    else
-                    {
-                        LOG(1, "NAAH PLT ENTRY NOT FOUND");
-            		    callSem->setLink(new NormalLink(enforcement_func, Link::SCOPE_EXTERNAL_JUMP));
-                    }
-            		call->setSemantic(callSem);
-                    m1.append(call);
-                    ChunkMutator m2(func);
-                    m2.insertAfter(bl, block2); */
-                    /*
-            		{
-            			ChunkMutator m(bl, true);
-            			//m.prepend(call);
-                        if(before)
-            			     m.insertBeforeJumpTo(instr, call);
-                         else
-            			     m.append(call);
-
-            			return;
-            		}*/
-                    /*
-				}
-			}
-		}
-	}
-}
-*/
 
 void SyspartPass::visit(Function *func)
 {
@@ -112,22 +57,7 @@ void SyspartPass::visit(Function *func)
                 auto last =  (Instruction*)bl->getChildren()->genericGetLast();
                 if(auto cfi = dynamic_cast<ControlFlowInstruction *>(last->getSemantic())) 
                 {
-                    //cout<<"CFI at "<< std::hex<<last->getAddress()<<endl;
                     auto sem1 = last->getSemantic();
-                    /*
-		    if(auto linked = dynamic_cast<LinkedInstructionBase *>(sem1))
-                    {
-                        cout<<"LINKED INSTRUCTION BASE"<<endl;
-                    }
-                    if(auto linked = dynamic_cast<ControlFlowInstructionBase *>(sem1))
-                    {
-                        cout<<"CONTROL FLOW INSTRUCTION BASE "<<(linked->getSource())->getAddress()<<endl;
-                    }
-                    if((cfi->getMnemonic())[0] == 'j')
-                    {
-                       cout<<"JUMP HERE"<<endl;
-                    }
-		    */
                 }
                 m1.insertBefore(last, call);
 
@@ -145,42 +75,19 @@ void SyspartPass::visit(Function *func)
             callSem->setLink(new NormalLink(enforcement_func, Link::SCOPE_EXTERNAL_JUMP));
             call->setSemantic(callSem);
             m2.append(call);
-            //cout<<"Appended call"<<endl;
             m1.insertAfter(previous_sibling, block2);
-            //m1.insertBefore(previous_sibling, block2);
-            //auto last_instr = previous_sibling->getChildren()->genericGetLast();
-            //cout<<"Previous sibling "<<previous_sibling->getAddress()<<" "<<last_instr->getAddress()<<endl;
-
-            //ChunkMutator m1(previous_sibling);
-            //m1.append(call);
-            //m1.insertAfter(last_instr, call);
-            cout<<"Added block"<<endl;
+            
             for(auto bl : non_loop_parents)
             {
-                //if(bl->getAddress() == previous_sibling->getAddress())
-                //    continue;
+
                 auto last =  (Instruction*)bl->getChildren()->genericGetLast();
                 if(auto cfi = dynamic_cast<ControlFlowInstruction *>(last->getSemantic())) 
                 {
-                    cout<<"CFI at "<< std::hex<<last->getAddress()<<endl;
                     auto sem1 = last->getSemantic();
-                    if(auto linked = dynamic_cast<LinkedInstructionBase *>(sem1))
-                    {
-                        cout<<"LINKED INSTRUCTION BASE"<<endl;
-                    }
-                    if(auto linked = dynamic_cast<ControlFlowInstructionBase *>(sem1))
-                    {
-                        cout<<"CONTROL FLOW INSTRUCTION BASE "<<(linked->getSource())->getAddress()<<endl;
-                    }
                     if((cfi->getMnemonic())[0] == 'j')
                     {
                         auto link = last->getSemantic()->getLink();
                         last->getSemantic()->setLink(new NormalLink(call, link->getScope()));
-                        //auto sem1 = last->getSemantic();
-                        //if(auto linked = dynamic_cast<LinkedInstructionBase *>(sem1))
-                            //linked->setInstruction(call);
-                        //if(auto linked = dynamic_cast<ControlFlowInstructionBase *>(sem1))
-                            //linked->setSource(call);
                     }
                 }
             }

--- a/src/pass/syspartpass.cpp
+++ b/src/pass/syspartpass.cpp
@@ -1,0 +1,188 @@
+#include <vector>
+#include "syspartpass.h"
+#include "disasm/disassemble.h"
+#include "instr/register.h"
+#include "instr/concrete.h"
+#include "operation/mutator.h"
+
+
+#include "log/log.h"
+
+void SyspartPass::visit(Module *module) {
+#ifdef ARCH_X86_64
+    if(this->enforcement_func != NULL)
+    {
+        recurse(module);
+        return;
+    }
+	if(module->getName() != "module-(executable)")
+    {
+		recurse(module);
+        return;
+    }
+    auto instr = Disassemble::instruction({0xc3});  // ret
+    auto block = new Block();
+
+    auto symbol = new Symbol(0x0, 0, "testfn",
+       Symbol::TYPE_FUNC, Symbol::BIND_GLOBAL, 0, 0);
+    auto function = new Function(symbol);
+    function->setName(symbol->getName());
+    function->setPosition(new AbsolutePosition(0x0));
+
+    module->getFunctionList()->getChildren()->add(function);
+    function->setParent(module->getFunctionList());
+    ChunkMutator(function).append(block);
+    ChunkMutator(block).append(instr);
+
+    this->enforcement_func = function;
+    recurse(module);
+
+#endif
+}
+/*
+void SyspartPass::visit(Function *func)
+{
+
+    LOG(1, "SID "<<func->getName());
+	if((func->getName() == this->function->getName()) && (func->getAddress() == this->function->getAddress()))
+	{
+		for(auto bl : CIter::children(this->function))
+		{
+			for(auto instr : CIter::children(bl))
+			{
+				if(instr->getAddress() == this->address)
+				{
+                    auto block2 = new Block();
+                    //PositionFactory *positionFactory = PositionFactory::getInstance();
+                    //block2->setPosition(positionFactory->makePosition(bl, block2, bl->getSize()));
+                    ChunkMutator m1(block2);
+
+					auto call = new Instruction();
+					auto callSem = new ControlFlowInstruction(
+            X86_INS_CALL, call, "\xe8", "call", 4);
+                    auto module = (Module*)func->getParent()->getParent();
+                    auto newRef = CIter::named(module->getPLTList())->find(enforcement_func->getName());
+                    if(newRef)
+                    {
+                        LOG(1, "YEAH PLT ENTRY FOUND");
+                        callSem->setLink(new PLTLink(newRef->getAddress(), newRef));
+                    }
+                    else
+                    {
+                        LOG(1, "NAAH PLT ENTRY NOT FOUND");
+            		    callSem->setLink(new NormalLink(enforcement_func, Link::SCOPE_EXTERNAL_JUMP));
+                    }
+            		call->setSemantic(callSem);
+                    m1.append(call);
+                    ChunkMutator m2(func);
+                    m2.insertAfter(bl, block2); */
+                    /*
+            		{
+            			ChunkMutator m(bl, true);
+            			//m.prepend(call);
+                        if(before)
+            			     m.insertBeforeJumpTo(instr, call);
+                         else
+            			     m.append(call);
+
+            			return;
+            		}*/
+                    /*
+				}
+			}
+		}
+	}
+}
+*/
+
+void SyspartPass::visit(Function *func)
+{
+    if((func->getName() == this->function->getName()) && (func->getAddress() == this->function->getAddress()))
+    {
+        if(special)
+        {
+            auto call = new Instruction();
+                    auto callSem = new ControlFlowInstruction(
+            X86_INS_CALL, call, "\xe8", "call", 4);
+            callSem->setLink(new NormalLink(enforcement_func, Link::SCOPE_EXTERNAL_JUMP));
+            call->setSemantic(callSem);
+             for(auto bl : non_loop_parents)
+             {
+                ChunkMutator m1(bl);
+                auto last =  (Instruction*)bl->getChildren()->genericGetLast();
+                if(auto cfi = dynamic_cast<ControlFlowInstruction *>(last->getSemantic())) 
+                {
+                    cout<<"CFI at "<< std::hex<<last->getAddress()<<endl;
+                    auto sem1 = last->getSemantic();
+                    if(auto linked = dynamic_cast<LinkedInstructionBase *>(sem1))
+                    {
+                        cout<<"LINKED INSTRUCTION BASE"<<endl;
+                    }
+                    if(auto linked = dynamic_cast<ControlFlowInstructionBase *>(sem1))
+                    {
+                        cout<<"CONTROL FLOW INSTRUCTION BASE "<<(linked->getSource())->getAddress()<<endl;
+                    }
+                    if((cfi->getMnemonic())[0] == 'j')
+                    {
+                       cout<<"JUMP HERE"<<endl;
+                    }
+                }
+                m1.insertBefore(last, call);
+
+             }
+        }
+        else
+        {
+            ChunkMutator m1(func);
+
+            auto block2 = new Block();
+            ChunkMutator m2(block2);
+            auto call = new Instruction();
+                    auto callSem = new ControlFlowInstruction(
+            X86_INS_CALL, call, "\xe8", "call", 4);
+            callSem->setLink(new NormalLink(enforcement_func, Link::SCOPE_EXTERNAL_JUMP));
+            call->setSemantic(callSem);
+            m2.append(call);
+            //cout<<"Appended call"<<endl;
+            m1.insertAfter(previous_sibling, block2);
+            //m1.insertBefore(previous_sibling, block2);
+            //auto last_instr = previous_sibling->getChildren()->genericGetLast();
+            //cout<<"Previous sibling "<<previous_sibling->getAddress()<<" "<<last_instr->getAddress()<<endl;
+
+            //ChunkMutator m1(previous_sibling);
+            //m1.append(call);
+            //m1.insertAfter(last_instr, call);
+            cout<<"Added block"<<endl;
+            for(auto bl : non_loop_parents)
+            {
+                //if(bl->getAddress() == previous_sibling->getAddress())
+                //    continue;
+                auto last =  (Instruction*)bl->getChildren()->genericGetLast();
+                if(auto cfi = dynamic_cast<ControlFlowInstruction *>(last->getSemantic())) 
+                {
+                    cout<<"CFI at "<< std::hex<<last->getAddress()<<endl;
+                    auto sem1 = last->getSemantic();
+                    if(auto linked = dynamic_cast<LinkedInstructionBase *>(sem1))
+                    {
+                        cout<<"LINKED INSTRUCTION BASE"<<endl;
+                    }
+                    if(auto linked = dynamic_cast<ControlFlowInstructionBase *>(sem1))
+                    {
+                        cout<<"CONTROL FLOW INSTRUCTION BASE "<<(linked->getSource())->getAddress()<<endl;
+                    }
+                    if((cfi->getMnemonic())[0] == 'j')
+                    {
+                        auto link = last->getSemantic()->getLink();
+                        last->getSemantic()->setLink(new NormalLink(call, link->getScope()));
+                        //auto sem1 = last->getSemantic();
+                        //if(auto linked = dynamic_cast<LinkedInstructionBase *>(sem1))
+                            //linked->setInstruction(call);
+                        //if(auto linked = dynamic_cast<ControlFlowInstructionBase *>(sem1))
+                            //linked->setSource(call);
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/pass/syspartpass.h
+++ b/src/pass/syspartpass.h
@@ -1,0 +1,24 @@
+#ifndef EGALITO_PASS_SYSCALL_SANDBOX_H
+#define EGALITO_PASS_SYSCALL_SANDBOX_H
+
+#include<set>
+using namespace std;
+
+#include "chunkpass.h"
+
+class SyspartPass : public ChunkPass {
+private:
+    Program *program;
+    Function *function;
+    address_t address;
+    Function *enforcement_func;
+    bool special;
+    Block* previous_sibling;
+    set<Block*> non_loop_parents;
+public:
+    SyspartPass(Program *program, Function* function, address_t address, Function *enforcement_func, bool special, Block* previous_sibling, set<Block*> non_loop_parents ) : program(program), function(function), address(address), enforcement_func(enforcement_func), special(special), previous_sibling(previous_sibling), non_loop_parents(non_loop_parents) {}
+    virtual void visit(Function *func);
+    virtual void visit(Module *module);
+};
+
+#endif

--- a/test/framework/catch.hpp
+++ b/test/framework/catch.hpp
@@ -6487,7 +6487,7 @@ namespace Catch {
         static bool isSet;
         static struct sigaction oldSigActions [sizeof(signalDefs)/sizeof(SignalDefs)];
         static stack_t oldSigStack;
-        static char altStackMem[SIGSTKSZ];
+        static char altStackMem[4096];
 
         static void handleSignal( int sig ) {
             std::string name = "<unknown signal>";
@@ -6507,7 +6507,7 @@ namespace Catch {
             isSet = true;
             stack_t sigStack;
             sigStack.ss_sp = altStackMem;
-            sigStack.ss_size = SIGSTKSZ;
+            sigStack.ss_size = 4096;
             sigStack.ss_flags = 0;
             sigaltstack(&sigStack, &oldSigStack);
             struct sigaction sa = { 0 };
@@ -6538,7 +6538,7 @@ namespace Catch {
     bool FatalConditionHandler::isSet = false;
     struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs)/sizeof(SignalDefs)] = {};
     stack_t FatalConditionHandler::oldSigStack = {};
-    char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
+    char FatalConditionHandler::altStackMem[4096] = {};
 
 } // namespace Catch
 


### PR DESCRIPTION
Fix [issue](https://github.com/vidyalakshmir/SysPartCode/issues/3)

A relocation like R_X86_64_JUMP_SLOT calloc@@GLIBC_2.2.5 + 28454 means "resolve calloc, then add 28454 bytes to that address." The original code had no handling for R_X86_64_JUMP_SLOT in src/pass/handledatarelocs.cpp

Added a check at the top of the JUMP_SLOT block
When addend is non-zero, the target is a data reference (some offset past a symbol), not a function call. ExternalSymbolLink stores both the symbol and the offset, so the full address (symbol + addend) is preserved