### PR TITLE
Handle R_X86_64_JUMP_SLOT with addend and guard empty CFGs

### DIFF
--- a/src/pass/findsyscalls.cpp
+++ b/src/pass/findsyscalls.cpp
@@ -19,6 +19,12 @@ void FindSyscalls::visit(Function *function) {
     if (isSyscallFunction(function)) return;
 
     auto graph = new ControlFlowGraph(function);
+    if(graph->getCount() == 0) {
+        LOG(1, "Skipping function " << function->getName()
+            << " with empty CFG");
+        delete graph;
+        return;
+    }
     auto config = new UDConfiguration(graph);
     auto working = new UDRegMemWorkingSet(function, graph);
     auto usedef = new UseDef(config, working);

--- a/src/pass/handledatarelocs.cpp
+++ b/src/pass/handledatarelocs.cpp
@@ -169,6 +169,45 @@ Link *HandleDataRelocsPass::resolveVariableLink(Reloc *reloc, Module *module) {
             return nullptr;
         }
     }
+    else if(reloc->getType() == R_X86_64_JUMP_SLOT) {
+        if(reloc->getAddend() != 0) {
+            // Non-zero addend is a data reference (e.g. calloc + 28454),
+            // not a function call. Store as ExternalSymbolLink with offset.
+            LOG(0, "processing R_X86_64_JUMP_SLOT with addend ("
+                << std::hex << reloc->getAddress()
+                << ") in " << module->getName()
+                << ", symbol=" << reloc->getSymbol()->getName()
+                << ", addend=" << std::dec << reloc->getAddend());
+            auto externalSymbol = ExternalSymbolFactory(module)
+                .makeExternalSymbol(reloc->getSymbol());
+            return new ExternalSymbolLink(externalSymbol, reloc->getAddend());
+        }
+        if(!internal) {
+            LOG(0, "processing R_X86_64_JUMP_SLOT ("
+                << std::hex << reloc->getAddress()
+                << ") in " << module->getName());
+            auto l = PerfectLinkResolver().resolveExternally(
+                reloc->getSymbol(), conductor, module, weak, false, true);
+            if(!l) {
+                l = PerfectLinkResolver().resolveInternally(reloc, module, weak, false);
+            }
+            LOG(0, "link is " << l);
+            return l;
+        }
+        else {
+            LOG(0, "checking JUMP_SLOT relocation ["
+                << reloc->getSymbol()->getName() << "] for internal link");
+            auto l = PerfectLinkResolver().resolveInternally(reloc, module, weak, false);
+            if(auto v = dynamic_cast<AbsoluteDataLink *>(l)) {
+                auto externalSymbol = ExternalSymbolFactory(module)
+                    .makeExternalSymbol(reloc->getSymbol());
+                auto newLink = new InternalAndExternalDataLink(externalSymbol, v);
+                delete v;
+                return newLink;
+            }
+            return nullptr;
+        }
+    }
     else if(reloc->getType() == R_X86_64_64) {
         // want a non-relative lookup
         auto l =  PerfectLinkResolver().resolveInternally(reloc, module, weak, false);


### PR DESCRIPTION
[Issue](https://github.com/vidyalakshmir/SysPartCode/issues/3)
## Summary
- Handle R_X86_64_JUMP_SLOT relocations with non-zero addends (e.g. `calloc + 28454`) as data references using ExternalSymbolLink
- Guard against SIGSEGV in FindSyscalls when visiting functions with empty CFGs (0 basic blocks)

## Details
A relocation like `R_X86_64_JUMP_SLOT calloc@@GLIBC_2.2.5 + 28454` means "resolve calloc, then add 28454 bytes." Previously unhandled, causing an exception. When addend is non-zero, the target is a data reference, not a function call.

The empty CFG guard prevents a crash in `SccOrder::genFull(0)` when iterating over all functions including those from dependency libraries that were not fully disassembled.